### PR TITLE
Moved `colors` from dev dependency to dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   },
   "homepage": "https://github.com/ruslansavenok/postcss-wrap",
   "dependencies": {
+    "colors": "^1.1.2",
     "postcss": "^5.0.13"
   },
   "devDependencies": {
     "ava": "^0.9.1",
-    "colors": "^1.1.2",
     "eslint": "^1.10.3"
   },
   "scripts": {


### PR DESCRIPTION
I imagine you're using npm3 and that's why you didn't notice this was an issue!
