### PR TITLE
Don't use `colors` when used in web browsers

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var postcss = require('postcss')
-require('colors')
 
 module.exports = postcss.plugin('postcss-wrap', function (opts) {
   opts = opts || {}
@@ -10,6 +9,8 @@ module.exports = postcss.plugin('postcss-wrap', function (opts) {
     /\%$/
   ]
 
+  var selectorRequiredWarning = 'opts.selector must be specified'
+
   if (opts.skip instanceof Array) {
     selectorsBlacklist = selectorsBlacklist.concat(opts.skip)
   } else if (opts.skip instanceof RegExp) {
@@ -18,7 +19,11 @@ module.exports = postcss.plugin('postcss-wrap', function (opts) {
 
   return function (css, result) {
     if (!opts.selector) {
-      result.warn('opts.selector must be specified'.red)
+      if (typeof window === 'undefined') {
+        result.warn(require('colors/safe').red(selectorRequiredWarning))
+      } else {
+        result.warn(selectorRequiredWarning)
+      }
       return
     }
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "postcss": "^5.0.13"
   },
   "devDependencies": {
-    "ava": "^0.9.1",
+    "ava": "^0.10.0",
     "eslint": "^1.10.3"
   },
   "scripts": {


### PR DESCRIPTION
In a universal app, we want to use `postcss-wrap` also on the client-side with Webpack. Unfortunately, our build fails with `Critical dependencies` warnings caused by [this issue](https://github.com/Marak/colors.js/issues/137) with the `colors` package.

This change allows to have module bundlers like Webpack leave out the `colors` dependency in the resulting browser bundle (e.g. for use with universal apps). `colors` doesn't seem to work in web browsers anyway.

Also, use the safe API of `colors`, which doesn't extend `String.prototype`.